### PR TITLE
feat(issue-templates): add feature request and bug report templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,58 @@
+name: 🐛 Bug
+description: Report an issue to help improve the project.
+title: "[BUG] <description>"
+labels: ["bug", "status: awaiting triage"]
+body:
+  - type: checkboxes
+    id: duplicates
+    attributes:
+      label: Has this bug been raised before?
+      description: Increase the chances of your issue being accepted by making sure it has not been raised before.
+      options:
+        - label: I have checked "open" AND "closed" issues and this is not a duplicate
+          required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of the bug you have found. Please include relevant information and resources (for example the steps to reproduce the bug)
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: To help us recreate the bug, provide a numbered list of the exact steps taken to trigger the buggy behavior.
+      value: |
+        Include any relevant details like:
+
+        - What page you were on...
+        - What you were trying to do...
+        - What went wrong...
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: Please add screenshots if applicable
+    validations:
+      required: false
+  - type: dropdown
+    id: assignee
+    attributes:
+      label: Do you want to work on this issue?
+      multiple: false
+      options:
+        - "No"
+        - "Yes"
+      default: 0
+    validations:
+      required: false
+  - type: textarea
+    id: extrainfo
+    attributes:
+      label: If "yes" to above, please explain how you would technically implement this
+      description: For example reference any existing code
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,51 @@
+name: 💡 General Feature Request
+description: Have a new idea/feature? Let us know...
+title: "[FEATURE] <description>"
+labels: ["enhancement", "feature", "status: awaiting triage"]
+body:
+  - type: checkboxes
+    id: duplicates
+    attributes:
+      label: Is this a unique feature?
+      description: Increase the chances of your issue being accepted by making sure it has not been raised before.
+      options:
+        - label: I have checked "open" AND "closed" issues and this is not a duplicate
+          required: true
+  - type: textarea
+    attributes:
+      label: Is your feature request related to a problem/unavailable functionality? Please describe.
+      description: A clear and concise description of what the problem is (for example "I'm always frustrated when [...]").
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Proposed Solution
+      description: A clear description of the enhancement you propose. Please include relevant information and resources (for example another project's implementation of this feature).
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: Please add screenshots of the before and/or after the proposed changes.
+    validations:
+      required: false
+  - type: dropdown
+    id: assignee
+    attributes:
+      label: Do you want to work on this issue?
+      multiple: false
+      options:
+        - "No"
+        - "Yes"
+      default: 0
+    validations:
+      required: false
+  - type: textarea
+    id: extrainfo
+    attributes:
+      label: If "yes" to above, please explain how you would technically implement this (issue will not be assigned if this is skipped)
+      description: For example reference any existing code or library
+    validations:
+      required: false


### PR DESCRIPTION
- Added feature_request.yml for submitting new feature ideas.
- Added bug_report.yml for reporting issues and bugs.

These templates help streamline the process of submitting feature requests and bug reports, ensuring all necessary information is provided.

Related issues: #9

@kasinadhsarma Can you please merge this under hactoberfest?