### PR TITLE
Fix ESLint structuredClone error in Vercel deployment workflow

### DIFF
--- a/.github/workflows/vercel-deployment.yml
+++ b/.github/workflows/vercel-deployment.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
           cache: 'npm'
           cache-dependency-path: './frontend/package-lock.json'
 

--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -1,3 +1,5 @@
+require('core-js/stable/structured-clone');
+
 module.exports = {
   env: {
     browser: true,

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,3 +1,5 @@
+require('core-js/stable/structured-clone');
+
 const js = require('@eslint/js');
 const tsPlugin = require('@typescript-eslint/eslint-plugin');
 const tsParser = require('@typescript-eslint/parser');

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "@testing-library/user-event": "^14.5.2",
     "@types/react-router-dom": "^5.3.3",
     "axios": "^1.7.7",
+    "core-js": "^3.30.0",
     "framer-motion": "^11.11.1",
     "lucide-react": "^0.312.0",
     "react": "^18.3.1",


### PR DESCRIPTION
Related to #61

Fix the linting error in the Vercel Deployment workflow by adding a polyfill for `structuredClone` and updating Node.js version.

* **Add polyfill for `structuredClone`**:
  - Modify `frontend/.eslintrc.cjs` to require `core-js/stable/structured-clone`.
  - Modify `frontend/eslint.config.js` to require `core-js/stable/structured-clone`.
* **Update dependencies**:
  - Add `core-js` as a dependency in `frontend/package.json`.
* **Update Node.js version**:
  - Change Node.js version to 18.x in `.github/workflows/vercel-deployment.yml`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/VishwamAI/jobcity/issues/61?shareId=3277f603-8284-41a7-a83a-29864a8eac6e).